### PR TITLE
Remove Chrome Frame HTTP header hint

### DIFF
--- a/lighttpd.conf
+++ b/lighttpd.conf
@@ -33,7 +33,7 @@ server.modules = (
 
 # Sent Response Headers
 # opt-in to the future - remove meta tag from page
-setenv.add-response-header = ( "X-UA-Compatible" => "IE=edge,chrome=1" )
+setenv.add-response-header = ( "X-UA-Compatible" => "IE=edge" )
 
 # File uploads
 # Make sure this folder exists and is writable to server.username


### PR DESCRIPTION
Google officially announced that they've decided to retire Chrome Frame,
and this HTTP header hint can be removed.

See http://blog.chromium.org/2013/06/retiring-chrome-frame.html.

This would fix #1
