### PR TITLE
Add .xz MIME type

### DIFF
--- a/lighttpd.conf
+++ b/lighttpd.conf
@@ -228,7 +228,8 @@ mimetype.assign = (
     ".xpm"          =>  "image/x-xpixmap",
     ".xwd"          =>  "image/x-xwindowdump",
     ".zip"          =>  "application/zip",
-
+    ".xz"           =>  "application/x-xz",
+    ".tar.xz"       =>  "application/x-xz-compressed-tar",
 
   # Default MIME type
 


### PR DESCRIPTION
.xz (LZMA/LZMA2/7z-ish) is pretty popular now. It is now an option or the default package format for the Linux kernel and many Linux distros. I also considered adding ".lzma" and ".tar.lzma": same thing, but I think .xz is more standard and .lzma won't catch on.